### PR TITLE
Adding user to docker group.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,7 +29,7 @@ If you prefer, you can install amoni into any Python environment using:
 
 User Permissions
 ----------------
-Make sure you add your user to the docker group. This is how you do it on Ubuntu 22.04, I imagine other distros to be similar :
+Make sure you add your user to the docker group. For example, on Linux:
 
 .. code-block:: shell
 


### PR DESCRIPTION
A warning on ensuring the user is in the docker group to avoid socket permission errors.