### PR TITLE
Build test_runner for multiple platforms

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -50,4 +50,5 @@ jobs:
           context: .
           file: docker/test_runner/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ env.REGISTRY }}/anvilistas/amoni/test_runner:latest


### PR DESCRIPTION
Add `arm` build for `test_runner` for Apple Silicon support.