### PR TITLE
Configure ports for database and app, and set app URL

### DIFF
--- a/amoni/api.py
+++ b/amoni/api.py
@@ -145,19 +145,28 @@ def start_service(name: str, detach: bool) -> None:
     detach
         Whether to detach from the service console
     """
-    cmd = ["docker-compose", "up"]
-    if detach:
-        cmd.append("-d")
-    cmd.append(name)
     try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to start service: {e}")
+        docker.compose.up([name], detach=detach)
+    except Exception:
+        cmd = ["docker-compose", "up"]
+        if detach:
+            cmd.append("-d")
+        cmd.append(name)
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to start service: {e}")
 
 
 def stop_services() -> None:
     """Stop all amoni services"""
-    docker.compose.down()
+    try:
+        docker.compose.down()
+    except Exception:
+        try:
+            subprocess.run(["docker-compose", "down"], check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to stop services: {e}")
 
 
 def run_service(name: str, remove: bool = True) -> None:

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -30,26 +30,28 @@ ANVIL_CONFIG_FILE = Path("app", "config.yaml")
 TABLE_STUB_FILE = Path("anvil-stubs", "tables", "app_tables.pyi")
 
 
-def get_ports() -> Tuple[str, str, str]:
-    """Get the configured ports and origin URL for app and database servers
+def get_ports() -> Tuple[str, str, str, bool]:
+    """Get the configured ports and origin URL for app and database servers.
+    If no .env file is found, falls back to default values:
+    - app_port=3030
+    - db_port=5432
+    - origin_url=http://localhost:3030
 
     Returns
     -------
-    Tuple[str, str, str]
-        A tuple containing (app_port, db_port, origin_url)
+    Tuple[str, str, str, bool]
+        A tuple containing (app_port, db_port, origin_url, env_file_found)
+        where env_file_found indicates if the .env file was loaded successfully
     """
     # Look for .env in current directory
-    if not load_dotenv(dotenv_path=".env"):
-        print(
-            "Warning: no .env file found. Falling back to default values for app url and ports"
-        )
+    env_file_found = load_dotenv(dotenv_path=".env")
 
     # Use environment variables if set, otherwise use defaults
     app_port = os.environ.get("AMONI_APP_PORT", "3030")
     db_port = os.environ.get("AMONI_DB_PORT", "5432")
     origin_url = os.environ.get("ORIGIN_URL", f"http://localhost:{app_port}")
 
-    return app_port, db_port, origin_url
+    return app_port, db_port, origin_url, env_file_found
 
 
 def _commit_all(

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -8,23 +8,10 @@ import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-
-def get_ports() -> Tuple[str, str]:
-    """Get the configured ports for app and database servers
-
-    Returns
-    -------
-    Tuple[str, str]
-        A tuple containing (app_port, db_port)
-    """
-    app_port = os.environ.get("AMONI_APP_PORT", "3030")
-    db_port = os.environ.get("AMONI_DB_PORT", "5432")
-    return app_port, db_port
-
-
 import keyring
 import pygit2
 from cookiecutter.main import cookiecutter
+from dotenv import load_dotenv
 from python_on_whales import docker
 from yaml import dump, load
 
@@ -41,6 +28,22 @@ COOKIECUTTER_URL = os.environ.get(
 )
 ANVIL_CONFIG_FILE = Path("app", "config.yaml")
 TABLE_STUB_FILE = Path("anvil-stubs", "tables", "app_tables.pyi")
+
+
+def get_ports() -> Tuple[str, str]:
+    """Get the configured ports for app and database servers
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple containing (app_port, db_port)
+    """
+    # Load environment variables from .env file
+    load_dotenv()
+
+    app_port = os.environ.get("AMONI_APP_PORT", "3030")
+    db_port = os.environ.get("AMONI_DB_PORT", "5432")
+    return app_port, db_port
 
 
 def _commit_all(
@@ -246,7 +249,7 @@ def add_table(
     server_permissions: str = "full",
     columns: List = None,
 ):
-    columns = columns if columns is None else []
+    columns = columns if columns is not None else []
     config = _get_app_config(app)
     table = {
         "title": name,

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -5,6 +5,7 @@
 #
 # This software is published at https://github.com/anvilistas/amoni
 import os
+import subprocess
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -144,7 +145,14 @@ def start_service(name: str, detach: bool) -> None:
     detach
         Whether to detach from the service console
     """
-    docker.compose.up([name], detach=detach)
+    cmd = ["docker-compose", "up"]
+    if detach:
+        cmd.append("-d")
+    cmd.append(name)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to start service: {e}")
 
 
 def stop_services() -> None:

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -30,20 +30,38 @@ ANVIL_CONFIG_FILE = Path("app", "config.yaml")
 TABLE_STUB_FILE = Path("anvil-stubs", "tables", "app_tables.pyi")
 
 
-def get_ports() -> Tuple[str, str]:
-    """Get the configured ports for app and database servers
+def get_ports() -> Tuple[str, str, str]:
+    """Get the configured ports and origin URL for app and database servers
 
     Returns
     -------
-    Tuple[str, str]
-        A tuple containing (app_port, db_port)
-    """
-    # Load environment variables from .env file
-    load_dotenv()
+    Tuple[str, str, str]
+        A tuple containing (app_port, db_port, origin_url)
 
-    app_port = os.environ.get("AMONI_APP_PORT", "3030")
-    db_port = os.environ.get("AMONI_DB_PORT", "5432")
-    return app_port, db_port
+    Raises
+    ------
+    RuntimeError
+        If .env file is not found or required environment variables are missing
+    """
+    # Look for .env in current directory
+    if not load_dotenv(dotenv_path=".env"):
+        raise RuntimeError(
+            "No .env file found. Please create one with required environment variables."
+        )
+
+    app_port = os.environ.get("AMONI_APP_PORT")
+    if not app_port:
+        raise RuntimeError("AMONI_APP_PORT not found in .env file")
+
+    db_port = os.environ.get("AMONI_DB_PORT")
+    if not db_port:
+        raise RuntimeError("AMONI_DB_PORT not found in .env file")
+
+    origin_url = os.environ.get("ORIGIN_URL")
+    if not origin_url:
+        raise RuntimeError("ORIGIN_URL not found in .env file")
+
+    return app_port, db_port, origin_url
 
 
 def _commit_all(

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -22,7 +22,9 @@ except ImportError:
 
 __version__ = "0.0.13"
 
-COOKIECUTTER_URL = "https://github.com/anvilistas/amoni-cookiecutter.git"
+COOKIECUTTER_URL = os.environ.get(
+    "AMONI_COOKIECUTTER_PATH", "https://github.com/anvilistas/amoni-cookiecutter.git"
+)
 ANVIL_CONFIG_FILE = Path("app", "config.yaml")
 TABLE_STUB_FILE = Path("anvil-stubs", "tables", "app_tables.pyi")
 

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -6,7 +6,21 @@
 # This software is published at https://github.com/anvilistas/amoni
 import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
+
+
+def get_ports() -> Tuple[str, str]:
+    """Get the configured ports for app and database servers
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple containing (app_port, db_port)
+    """
+    app_port = os.environ.get("AMONI_APP_PORT", "3030")
+    db_port = os.environ.get("AMONI_DB_PORT", "5432")
+    return app_port, db_port
+
 
 import keyring
 import pygit2

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -12,9 +12,6 @@ from cookiecutter.exceptions import OutputDirExistsException
 from .. import api
 from . import app, echo, theme
 
-# Initialize environment variables and get configured ports
-app_port, db_port = api.get_ports()
-
 __version__ = "0.0.13"
 
 cmd = typer.Typer()

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -12,7 +12,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 from .. import api
 from . import app, echo, theme
 
-# Get configured ports
+# Initialize environment variables and get configured ports
 app_port, db_port = api.get_ports()
 
 __version__ = "0.0.13"
@@ -55,10 +55,12 @@ def start(
         api.pull_image("db")
     with echo.working("Starting anvil app and database servers"):
         api.start_service("app", detach=True)
-    echo.progress(f"Your app is available at http://localhost:{app_port}")
-    echo.progress(f"Database is available at localhost:{db_port}")
+    # Get latest port values in case .env was modified
+    current_app_port, current_db_port = api.get_ports()
+    echo.progress(f"Your app is available at http://localhost:{current_app_port}")
+    echo.progress(f"PostgreSQL database is available at localhost:{current_db_port}")
     if launch:
-        typer.launch(f"http://localhost:{app_port}")
+        typer.launch(f"http://localhost:{current_app_port}")
     echo.done()
 
 

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -12,6 +12,9 @@ from cookiecutter.exceptions import OutputDirExistsException
 from .. import api
 from . import app, echo, theme
 
+# Get configured ports
+app_port, db_port = api.get_ports()
+
 __version__ = "0.0.13"
 
 cmd = typer.Typer()
@@ -52,9 +55,10 @@ def start(
         api.pull_image("db")
     with echo.working("Starting anvil app and database servers"):
         api.start_service("app", detach=True)
-    echo.progress("Your app is available at http://localhost:3030")
+    echo.progress(f"Your app is available at http://localhost:{app_port}")
+    echo.progress(f"Database is available at localhost:{db_port}")
     if launch:
-        typer.launch("http://localhost:3030")
+        typer.launch(f"http://localhost:{app_port}")
     echo.done()
 
 

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -53,7 +53,11 @@ def start(
         api.pull_image("db")
     try:
         # Get configuration before starting services to fail fast if .env is missing
-        current_app_port, current_db_port, origin_url = api.get_ports()
+        current_app_port, current_db_port, origin_url, env_file_found = api.get_ports()
+        if not env_file_found:
+            echo.warn(
+                "No .env file found. Falling back to default values for app url and ports"
+            )
 
         with echo.working("Starting anvil app and database servers"):
             api.start_service("app", detach=True)

--- a/amoni/cli/app.py
+++ b/amoni/cli/app.py
@@ -32,14 +32,18 @@ def add(
         raise typer.BadParameter(
             "You must specify the app id to add it as a dependency"
         )
-    api.add_submodule(url, Path("app", name), name)
-    echo.progress(f"Added {name} as a submodule in the app directory")
-    if as_dependency:
-        api.set_dependency(id, name)
-    else:
-        api.set_app(name)
-        echo.progress(f"Updated config to set {name} as the app")
-        generated_stubs = api.generate_table_stubs(name)
-        if generated_stubs:
-            echo.progress(f"Created table definitions in {api.TABLE_STUB_FILE}")
-    echo.done()
+    try:
+        api.add_submodule(url, Path("app", name), name)
+        echo.progress(f"Added {name} as a submodule in the app directory")
+        if as_dependency:
+            api.set_dependency(id, name)
+        else:
+            api.set_app(name)
+            echo.progress(f"Updated config to set {name} as the app")
+            generated_stubs = api.generate_table_stubs(name)
+            if generated_stubs:
+                echo.progress(f"Created table definitions in {api.TABLE_STUB_FILE}")
+        echo.done()
+    except RuntimeError as e:
+        echo.error(str(e))
+        raise typer.Exit(1)

--- a/amoni/cli/echo.py
+++ b/amoni/cli/echo.py
@@ -16,7 +16,7 @@ __version__ = "0.0.13"
 CLEAR_LINE = "\r\033[K"
 EMOJI_ANIMATION = {"frames": ("⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"), "interval": 0.1}
 ASCII_ANIMATION = {"frames": ("   ", ".  ", ".. ", "..."), "interval": 0.5}
-DECORATIONS = {"error": "⛔", "done": "✨️"}
+DECORATIONS = {"error": "⛔", "done": "✨️", "warn": "⚠️"}
 
 
 def _emojis_work():
@@ -34,6 +34,10 @@ def _decorate(message, decoration):
 
 def error(message):
     typer.secho(_decorate(message, "error"), fg=typer.colors.RED, err=True)
+
+
+def warn(message):
+    typer.secho(_decorate(message, "warn"), fg=typer.colors.YELLOW, err=True)
 
 
 def done():

--- a/amoni/cli/echo.py
+++ b/amoni/cli/echo.py
@@ -37,6 +37,13 @@ def error(message):
 
 
 def warn(message):
+    """Display a warning message in yellow with a warning emoji
+
+    Parameters
+    ----------
+    message : str
+        The warning message to display
+    """
     typer.secho(_decorate(message, "warn"), fg=typer.colors.YELLOW, err=True)
 
 

--- a/amoni/cli/theme.py
+++ b/amoni/cli/theme.py
@@ -23,6 +23,10 @@ cmd = typer.Typer()
 @cmd.command()
 def build(app: str = typer.Argument(..., help="App folder name")):
     """Build the theme for the app"""
-    api.build_theme(app)
-    echo.progress(f"Created theme.css in app/{app}/theme/assets")
-    echo.done()
+    try:
+        api.build_theme(app)
+        echo.progress(f"Created theme.css in app/{app}/theme/assets")
+        echo.done()
+    except RuntimeError as e:
+        echo.error(str(e))
+        raise typer.Exit(1)

--- a/docs/howto/configure_ports.rst
+++ b/docs/howto/configure_ports.rst
@@ -13,7 +13,15 @@ External Ports (Host Machine):
 * Default port 3030 for accessing the Anvil app (configurable)
 * Default port 5432 for accessing PostgreSQL (configurable)
 
-You can customize these ports using environment variables in a ``.env`` file:
+You can customize these ports using environment variables in a ``.env`` file. If no ``.env`` file is found, amoni will fall back to these default values:
+
+.. code-block:: bash
+
+    AMONI_APP_PORT=3030  # Port for accessing the Anvil app
+    AMONI_DB_PORT=5432   # Port for accessing the PostgreSQL database
+    ORIGIN_URL=http://localhost:3030  # Default localhost URL
+
+A warning message will be displayed when using default values. To set custom values:
 
 .. code-block:: bash
 

--- a/docs/howto/configure_ports.rst
+++ b/docs/howto/configure_ports.rst
@@ -83,7 +83,7 @@ Using with Cloudflare Tunnels
 When using Cloudflare Tunnels to expose your app to the internet:
 
 1. Set ``disable-tls: true`` in your ``config.yaml``:
-   
+
    .. code-block:: yaml
 
        disable-tls: true  # Required for Cloudflare Tunnel

--- a/docs/howto/configure_ports.rst
+++ b/docs/howto/configure_ports.rst
@@ -1,0 +1,111 @@
+Configure Ports and Origin URL
+=============================
+
+Amoni uses a two-port system:
+
+Internal Ports (Docker):
+
+* Port 3030 for the Anvil app server (fixed in config.yaml)
+* Port 5432 for PostgreSQL (standard PostgreSQL port)
+
+External Ports (Host Machine):
+
+* Default port 3030 for accessing the Anvil app (configurable)
+* Default port 5432 for accessing PostgreSQL (configurable)
+
+You can customize these ports using environment variables in a ``.env`` file:
+
+.. code-block:: bash
+
+    # .env file
+    AMONI_APP_PORT=8080   # Custom port for the Anvil app
+    AMONI_DB_PORT=5433    # Custom port for the database
+
+Creating a .env File
+-------------------
+
+1. Copy the environment template file:
+
+   .. code-block:: bash
+
+       cp env.template .env
+
+   Note: The ``env.template`` file is provided by default when you create a new project with ``amoni init``.
+
+2. Edit the ``.env`` file to set your desired ports:
+
+   .. code-block:: bash
+
+       # Custom port configuration
+       AMONI_APP_PORT=8080
+       AMONI_DB_PORT=5433
+
+   Note: If you don't set these variables, the default ports will be used.
+
+Port and Origin Configuration Details
+----------------------------------
+
+AMONI_APP_PORT
+^^^^^^^^^^^^^^
+* Controls the external port where your Anvil app will be accessible on your host machine
+* Maps to the internal port 3030 (fixed in config.yaml)
+* Default external port: 3030
+* Example: Setting AMONI_APP_PORT=8080 makes the app available at ``http://localhost:8080``
+
+AMONI_DB_PORT
+^^^^^^^^^^^^^
+* Controls the external port where PostgreSQL will be accessible on your host machine
+* Maps to the internal port 5432 (standard PostgreSQL port)
+* Default external port: 5432
+* Useful when you need to:
+
+  * Connect to the database using external tools
+  * Run multiple Amoni projects simultaneously
+  * Avoid conflicts with existing PostgreSQL installations
+
+Origin URL Configuration
+^^^^^^^^^^^^^^^^^^^^^
+* Controls the public URL where your app will be accessible
+* Default: ``http://localhost:${AMONI_APP_PORT}``
+* Examples:
+
+  * Local development: ``http://localhost:8080`` (when AMONI_APP_PORT=8080)
+  * Public domain: ``https://myapp.example.com``
+
+* Use cases:
+
+  * Running behind a reverse proxy
+  * Deploying with a custom domain
+  * Testing with different ports
+
+Using with Cloudflare Tunnels
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+When using Cloudflare Tunnels to expose your app to the internet:
+
+1. Set ``disable-tls: true`` in your ``config.yaml``:
+   
+   .. code-block:: yaml
+
+       disable-tls: true  # Required for Cloudflare Tunnel
+
+2. Set your ORIGIN_URL to your Cloudflare domain:
+
+   .. code-block:: bash
+
+       ORIGIN_URL=https://myapp.example.com
+
+This configuration works because:
+
+* Cloudflare Tunnel handles the TLS termination
+* Traffic between Cloudflare and your app is already secure
+* The app server doesn't need to handle HTTPS directly
+
+Best Practices
+-------------
+
+1. Never commit your ``.env`` file to version control
+2. Always use ``env.template`` as a template
+3. Document any custom port requirements in your project's README
+4. Consider port availability when choosing custom ports
+5. Use HTTPS for production origin URLs
+6. Enable ``disable-tls`` when using Cloudflare Tunnels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "keyring",
     "pygit2",
     "python-dotenv",
-    "python-on-whales",
     "pyyaml",
     "typer",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "cookiecutter",
     "keyring",
     "pygit2",
+    "python-dotenv",
     "python-on-whales",
     "pyyaml",
     "typer",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argcomplete==2.0.0
+python-dotenv==1.0.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
 click==8.1.3


### PR DESCRIPTION
A bunch of changes to make this happen:
- Create an .env file as part of the cookiecutter, along with changes to the cookiecutter repo (will create a separate PR for that repo)
- Using dotenv to pull in the .env file and env vars
- Added a 2s pause to launch browser, I noticed it took a second and I had to reload the browser
- added docs, including blurb for cloudflare tunnels