### PR TITLE
Simplify dependency install and add interactive setup

### DIFF
--- a/amoni/api.py
+++ b/amoni/api.py
@@ -43,10 +43,8 @@ def get_ports() -> Tuple[str, str, str, bool]:
         A tuple containing (app_port, db_port, origin_url, env_file_found)
         where env_file_found indicates if the .env file was loaded successfully
     """
-    # Look for .env in current directory
     env_file_found = load_dotenv(dotenv_path=".env")
 
-    # Use environment variables if set, otherwise use defaults
     app_port = os.environ.get("AMONI_APP_PORT", "3030")
     db_port = os.environ.get("AMONI_DB_PORT", "5432")
     origin_url = os.environ.get("ORIGIN_URL", f"http://localhost:{app_port}")
@@ -391,9 +389,7 @@ def checkout_version(app: str, version: str = None) -> None:
 
     app_path = Path("app", app)
 
-    # Use git commands directly for more reliable submodule version management
     try:
-        # First fetch all tags and branches
         subprocess.run(
             ["git", "fetch", "--tags"],
             cwd=app_path,
@@ -402,7 +398,6 @@ def checkout_version(app: str, version: str = None) -> None:
             text=True,
         )
 
-        # Try to checkout the version
         subprocess.run(
             ["git", "checkout", version],
             cwd=app_path,

--- a/amoni/api.py
+++ b/amoni/api.py
@@ -371,3 +371,35 @@ def add_column(app: str, table: str, name: str, data_type: str, target: str = No
     config["db_schema"][table]["columns"].append(column)
     _save_app_config(app, config)
     _commit_all(f"Add {name} column to {table} data table")
+
+
+def checkout_version(app: str, version: str = None) -> None:
+    """Checkout a specific version (tag or branch) of a submodule
+
+    Parameters
+    ----------
+    app : str
+        The name of the app (submodule)
+    version : str, optional
+        The version (tag or branch) to checkout. If not provided,
+        stays on default branch.
+    """
+    if not version:
+        return
+
+    repo = pygit2.Repository(str(Path("app", app)))
+
+    # Try tag first
+    try:
+        tag_ref = repo.lookup_reference(f"refs/tags/{version}")
+        repo.checkout(tag_ref)
+        return
+    except KeyError:
+        pass
+
+    # Try branch
+    try:
+        branch_ref = repo.lookup_reference(f"refs/remotes/origin/{version}")
+        repo.checkout(branch_ref)
+    except KeyError:
+        raise RuntimeError(f"Version '{version}' not found as tag or branch in {app}")

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import typer
 from cookiecutter.exceptions import OutputDirExistsException
+from dotenv import load_dotenv, set_key
 
 from .. import api
 from . import app, echo, theme
@@ -63,7 +64,6 @@ def start(
         api.build_image("app")
         api.pull_image("db")
     try:
-        # Get configuration before starting services to fail fast if .env is missing
         current_app_port, current_db_port, origin_url, env_file_found = api.get_ports()
         if not env_file_found:
             echo.warn(
@@ -79,7 +79,7 @@ def start(
         )
         if launch:
             echo.progress("Waiting for services to be ready...")
-            time.sleep(2)  # Wait for 2 seconds before launching browser
+            time.sleep(2)
             try:
                 typer.launch(origin_url)
             except Exception:
@@ -121,20 +121,15 @@ def _interactive_setup(directory: Path):
     directory : Path
         The project directory where setup is being performed
     """
-    # Change to project directory
     os.chdir(directory)
-    # Get main app details
     repo_url = typer.prompt("Enter the repository URL for your main app")
     repo_name = typer.prompt("Enter the name for your main app")
 
-    # Add main app
     app.add(repo_url, repo_name, as_dependency=False)
 
-    # Parse dependencies from main app's anvil.yaml
     app_config = api._get_app_config(repo_name)
     deps = app_config.get("dependencies", [])
 
-    # Get dependency details
     for dep in deps:
         dep_id = dep["dep_id"]
         package_name = dep["resolution_hints"]["package_name"]
@@ -143,57 +138,19 @@ def _interactive_setup(directory: Path):
         )
         app.add(dep_url, package_name, id=dep_id, as_dependency=True, set_version=True)
 
-    # Get port configurations
     app_port = typer.prompt("Enter port number for the app server", default="3030")
     db_port = typer.prompt("Enter port number for the database", default="5432")
     origin_url = typer.prompt(
         "Enter origin URL", default=f"http://localhost:{app_port}"
     )
 
-    # Update .env file with configurations
     env_path = directory / ".env"
-    if env_path.exists():
-        with open(env_path) as f:
-            lines = f.readlines()
+    load_dotenv(env_path)
 
-        # Create a dictionary of existing variables and their values
-        env_vars = {}
-        for line in lines:
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                key, _ = line.split("=", 1)
-                env_vars[key] = True
+    set_key(env_path, "AMONI_APP_PORT", app_port)
+    set_key(env_path, "AMONI_DB_PORT", db_port)
+    set_key(env_path, "ORIGIN_URL", origin_url)
 
-        # Update or append new values
-        new_content = []
-        for line in lines:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                new_content.append(line)
-            elif "=" in line:
-                key, _ = line.split("=", 1)
-                if key == "AMONI_APP_PORT":
-                    new_content.append(f"AMONI_APP_PORT={app_port}")
-                elif key == "AMONI_DB_PORT":
-                    new_content.append(f"AMONI_DB_PORT={db_port}")
-                elif key == "ORIGIN_URL":
-                    new_content.append(f"ORIGIN_URL={origin_url}")
-                else:
-                    new_content.append(line)
-
-        # Add any missing variables
-        if "AMONI_APP_PORT" not in env_vars:
-            new_content.append(f"AMONI_APP_PORT={app_port}")
-        if "AMONI_DB_PORT" not in env_vars:
-            new_content.append(f"AMONI_DB_PORT={db_port}")
-        if "ORIGIN_URL" not in env_vars:
-            new_content.append(f"ORIGIN_URL={origin_url}")
-
-        # Write back with proper line endings
-        with open(env_path, "w") as f:
-            f.write("\n".join(new_content) + "\n")
-
-    # Commit changes
     api._commit_all("Update project configuration")
 
     echo.progress("Interactive setup completed successfully")

--- a/amoni/cli/amoni.py
+++ b/amoni/cli/amoni.py
@@ -144,7 +144,7 @@ def _interactive_setup(directory: Path):
         "Enter origin URL", default=f"http://localhost:{app_port}"
     )
 
-    env_path = directory / ".env"
+    env_path = Path(directory, ".env")
     load_dotenv(env_path)
 
     set_key(env_path, "AMONI_APP_PORT", app_port)

--- a/amoni/cli/app.py
+++ b/amoni/cli/app.py
@@ -46,18 +46,22 @@ def add(
             # Get main app name from config
             anvil_config = api.load(api.ANVIL_CONFIG_FILE.open(), Loader=api.Loader)
             main_app = Path(anvil_config["app"]).name
+            echo.progress(f"Main app: {main_app}")
 
             # Get main app's anvil.yaml
             app_config = api._get_app_config(main_app)
             deps = app_config.get("dependencies", [])
+            echo.progress(f"Found {len(deps)} dependencies")
 
             # Find this dependency's version info
             for dep in deps:
+                echo.progress(f"Checking dep {dep['dep_id']}")
                 if dep["dep_id"] == id:
                     version_info = dep.get("version", {})
                     version = version_info.get("version_tag") or version_info.get(
                         "version_branch"
                     )
+                    echo.progress(f"Found version info: {version_info}")
                     if version:
                         api.checkout_version(name, version)
                         echo.progress(f"Checked out version {version} for {name}")

--- a/amoni/cli/app.py
+++ b/amoni/cli/app.py
@@ -44,17 +44,14 @@ def add(
             api.set_dependency(id, name)
 
         if set_version:
-            # Get main app name from config
             anvil_config = api.load(api.ANVIL_CONFIG_FILE.open(), Loader=api.Loader)
             main_app = Path(anvil_config["app"]).name
             echo.progress(f"Main app: {main_app}")
 
-            # Get main app's anvil.yaml
             app_config = api._get_app_config(main_app)
             deps = app_config.get("dependencies", [])
             echo.progress(f"Found {len(deps)} dependencies")
 
-            # Find this dependency's version info
             for dep in deps:
                 echo.progress(f"Checking dep {dep['dep_id']}")
                 if dep["dep_id"] == id:

--- a/amoni/cli/app.py
+++ b/amoni/cli/app.py
@@ -26,6 +26,10 @@ def add(
         False,
         help="Whether to add the app as a dependency",
     ),
+    set_version: bool = typer.Option(
+        False,
+        help="Whether to set version from main app's anvil.yaml",
+    ),
 ):
     """Fetch an anvil app and set it as the app to run"""
     if as_dependency and not id:
@@ -34,8 +38,30 @@ def add(
         )
     api.add_submodule(url, Path("app", name), name)
     echo.progress(f"Added {name} as a submodule in the app directory")
+
     if as_dependency:
         api.set_dependency(id, name)
+
+        if set_version:
+            # Get main app name from config
+            anvil_config = api.load(api.ANVIL_CONFIG_FILE.open(), Loader=api.Loader)
+            main_app = Path(anvil_config["app"]).name
+
+            # Get main app's anvil.yaml
+            app_config = api._get_app_config(main_app)
+            deps = app_config.get("dependencies", [])
+
+            # Find this dependency's version info
+            for dep in deps:
+                if dep["dep_id"] == id:
+                    version_info = dep.get("version", {})
+                    version = version_info.get("version_tag") or version_info.get(
+                        "version_branch"
+                    )
+                    if version:
+                        api.checkout_version(name, version)
+                        echo.progress(f"Checked out version {version} for {name}")
+                    break
     else:
         api.set_app(name)
         echo.progress(f"Updated config to set {name} as the app")

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,10 +8,33 @@ project and run:
 
 .. code-block:: shell
 
-   amoni init demo
+   amoni init demo [--interactive]
 
 Amoni will now create a new directory named demo and set up the necessary
 files and directories within it.
+
+Interactive Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you use the ``--interactive`` (or ``-i``) flag, amoni will guide you through the setup process:
+
+1. Configure your main app:
+
+   * Enter the repository URL for your main app
+   * Specify a name for the app
+
+2. Configure dependencies:
+
+   * For each dependency in your main app's anvil.yaml
+   * Enter the repository URL for the dependency
+   * The version will be automatically set based on your main app's configuration
+
+3. Configure server settings:
+
+   * Set the app server port (default: 3030)
+   * Set the database port (default: 5432)
+   * Set the origin URL (default: http://localhost:<app_port>)
+
+All these settings will be saved in your project's configuration files.
 
 Start Your Servers
 ------------------

--- a/docs/howto/add_dependencies.rst
+++ b/docs/howto/add_dependencies.rst
@@ -9,7 +9,9 @@ To add a dependency to your project:
 
 .. code-block::
 
-   amoni app add --as-dependency <URL to the app> <Name of the dependency> <ID of the dependency>
+   amoni app add --as-dependency <URL to the app> <Name of the dependency> <ID of the dependency> [--set-version]
+
+The optional ``--set-version`` flag will automatically set the dependency's version based on the version information in your main app's anvil.yaml file. If not specified, the dependency will use its default branch.
 
 If the URL you provide is at `anvil.works` (perhaps from within the Anvil IDE), you
 will need to :ref:`configure-ssh` in order for it to work. Amoni does not support
@@ -21,4 +23,8 @@ to your amoni project. The submodule will be placed in the app folder.
 Amoni will also change the settings in `app/config.yaml` so that the app server will
 know where to find the dependency you've just added.
 
-Finally, amoni will commit the changes you've just made to your project.
+Finally, amoni will:
+
+1. Commit the changes you've just made to your project
+2. If ``--set-version`` was used, fetch and checkout the version specified in your main app's anvil.yaml
+3. Ensure the dependency is properly configured in your project


### PR DESCRIPTION
Changes
- ```amoni app add --as-dependency``` can now have a ```--set-version``` option which will automatically checkout the correct tag or branch of the dependency that is noted in the anvil.yaml
- There is now an interactive setup option ```amoni init <folder_name> -i```. This will walk the user through setting up ports, origin, dependencies, etc.